### PR TITLE
chore: Move translations to i18n

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-[DE](./CODE_OF_CONDUCT.de.md) [FR](./CODE_OF_CONDUCT.fr.md) [IT](./CODE_OF_CONDUCT.it.md) [RM](./CODE_OF_CONDUCT.rm.md) [EN](./CODE_OF_CONDUCT.md)
+[DE](./i18n/de/CODE_OF_CONDUCT.de.md) [FR](./i18n/fr/CODE_OF_CONDUCT.fr.md) [IT](./i18n/it/CODE_OF_CONDUCT.it.md) [RM](./i18n/rm/CODE_OF_CONDUCT.rm.md) [EN](./CODE_OF_CONDUCT.md)
 
 # Contributor Covenant Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-[DE](./CONTRIBUTING.de.md) [FR](./CONTRIBUTING.fr.md) [IT](./CONTRIBUTING.it.md) [RM](./CONTRIBUTING.rm.md) [EN](./CONTRIBUTING.md)
+[DE](./i18n/de/CONTRIBUTING.de.md) [FR](./i18n/fr/CONTRIBUTING.fr.md) [IT](./i18n/it/CONTRIBUTING.it.md) [RM](./i18n/rm/CONTRIBUTING.rm.md) [EN](./CONTRIBUTING.md)
 
 # Contributing
 

--- a/i18n/de/CODE_OF_CONDUCT.de.md
+++ b/i18n/de/CODE_OF_CONDUCT.de.md
@@ -1,5 +1,3 @@
-[DE](./CODE_OF_CONDUCT.de.md) [FR](./CODE_OF_CONDUCT.fr.md) [IT](./CODE_OF_CONDUCT.it.md) [RM](./CODE_OF_CONDUCT.rm.md) [EN](./CODE_OF_CONDUCT.md)
-
 # Vereinbarung über Verhaltenskodex für Mitwirkende
 
 ## Unsere Verpflichtung

--- a/i18n/de/CONTRIBUTING.de.md
+++ b/i18n/de/CONTRIBUTING.de.md
@@ -1,5 +1,3 @@
-[DE](./CONTRIBUTING.de.md) [FR](./CONTRIBUTING.fr.md) [IT](./CONTRIBUTING.it.md) [RM](./CONTRIBUTING.rm.md) [EN](./CONTRIBUTING.md)
-
 # Mitwirken
 
 Willkommen! Wir freuen uns, dass Sie zu diesem Projekt beitragen möchten!

--- a/i18n/fr/CODE_OF_CONDUCT.fr.md
+++ b/i18n/fr/CODE_OF_CONDUCT.fr.md
@@ -1,5 +1,3 @@
-[DE](./CODE_OF_CONDUCT.de.md) [FR](./CODE_OF_CONDUCT.fr.md) [IT](./CODE_OF_CONDUCT.it.md) [RM](./CODE_OF_CONDUCT.rm.md) [EN](./CODE_OF_CONDUCT.md)
-
 # Code de conduite _Contributor Covenant_
 
 ## Notre engagement

--- a/i18n/fr/CONTRIBUTING.fr.md
+++ b/i18n/fr/CONTRIBUTING.fr.md
@@ -1,5 +1,3 @@
-[DE](./CONTRIBUTING.de.md) [FR](./CONTRIBUTING.fr.md) [IT](./CONTRIBUTING.it.md) [RM](./CONTRIBUTING.rm.md) [EN](./CONTRIBUTING.md)
-
 # Contribuer
 
 Bienvenue ! Nous sommes ravis que vous souhaitiez contribuer à ce projet !

--- a/i18n/it/CODE_OF_CONDUCT.it.md
+++ b/i18n/it/CODE_OF_CONDUCT.it.md
@@ -1,5 +1,3 @@
-[DE](./CODE_OF_CONDUCT.de.md) [FR](./CODE_OF_CONDUCT.fr.md) [IT](./CODE_OF_CONDUCT.it.md) [RM](./CODE_OF_CONDUCT.rm.md) [EN](./CODE_OF_CONDUCT.md)
-
 # Codice di Comportamento del Collaboratore
 
 ## Il Nostro Impegno

--- a/i18n/it/CONTRIBUTING.it.md
+++ b/i18n/it/CONTRIBUTING.it.md
@@ -1,6 +1,4 @@
-[DE](./CONTRIBUTING.de.md) [FR](./CONTRIBUTING.fr.md) [IT](./CONTRIBUTING.it.md) [RM](./CONTRIBUTING.rm.md) [EN](./CONTRIBUTING.md)
-
-# Contribuire
+s# Contribuire
 
 Benvenuto! Siamo entusiasti che tu voglia contribuire a questo progetto!
 

--- a/i18n/rm/CODE_OF_CONDUCT.rm.md
+++ b/i18n/rm/CODE_OF_CONDUCT.rm.md
@@ -1,5 +1,3 @@
-[DE](./CODE_OF_CONDUCT.de.md) [FR](./CODE_OF_CONDUCT.fr.md) [IT](./CODE_OF_CONDUCT.it.md) [RM](./CODE_OF_CONDUCT.rm.md) [EN](./CODE_OF_CONDUCT.md)
-
 _Discommunicaziun: quai è ina translaziun maschinala. Ella è cumplettamain automatisada e na cumpiglia nagina intervenziun umana. La qualitad e l'exactadad da la translaziun maschinala pon variar dad in text a l'auter e tranter differents pèrs linguistics. ospo.ch na garantescha betg l'exactadad da la translaziun e n'accepta betg responsabladad per sbagls eventuals. As referi p.pl. al text uffizial en versiun originala englaisa en cas da dubis._
 
 # Codex da cumportament dal collavuratur

--- a/i18n/rm/CONTRIBUTING.rm.md
+++ b/i18n/rm/CONTRIBUTING.rm.md
@@ -1,5 +1,3 @@
-[DE](./CONTRIBUTING.de.md) [FR](./CONTRIBUTING.fr.md) [IT](./CONTRIBUTING.it.md) [RM](./CONTRIBUTING.rm.md) [EN](./CONTRIBUTING.md)
-
 _Discommunicaziun: quai è ina translaziun maschinala. Ella è cumplettamain automatisada e na cumpiglia nagina intervenziun umana. La qualitad e l'exactadad da la translaziun maschinala pon variar dad in text a l'auter e tranter differents pèrs linguistics. ospo.ch na garantescha betg l'exactadad da la translaziun e n'accepta betg responsabladad per sbagls eventuals. As referi p.pl. al text uffizial en versiun originala englaisa en cas da dubis._
 
 # Cooperation


### PR DESCRIPTION
## Description

This PR re-organizes content to dedicated locale folders (de, fr, it, rm). Kept language navigation in default english files only. 
